### PR TITLE
Upgrade cssparser to 0.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ bevy = { version = "0.12", default-features = false, features = [
     "bevy_text",
     "bevy_render",
 ] }
-cssparser = "0.32"
+cssparser = "0.33"
+cssparser-color = "0.1"
 smallvec = { version = "1.11", features = ["serde", "union", "const_generics"] }
 thiserror = "1.0.50"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ecss"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 categories = ["game-development", "gui", "web-programming"]
 description = "Allows using a subset of CSS to interact with Bevy ECS"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bevy = { version = "0.12", default-features = false, features = [
     "bevy_text",
     "bevy_render",
 ] }
-cssparser = "0.30"
+cssparser = "0.31"
 smallvec = { version = "1.11", features = ["serde", "union", "const_generics"] }
 thiserror = "1.0.50"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bevy = { version = "0.12", default-features = false, features = [
     "bevy_text",
     "bevy_render",
 ] }
-cssparser = "0.31"
+cssparser = "0.32"
 smallvec = { version = "1.11", features = ["serde", "union", "const_generics"] }
 thiserror = "1.0.50"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bevy = { version = "0.12", default-features = false, features = [
     "bevy_text",
     "bevy_render",
 ] }
-cssparser = "0.29"
+cssparser = "0.30"
 smallvec = { version = "1.11", features = ["serde", "union", "const_generics"] }
 thiserror = "1.0.50"
 

--- a/src/property/colors.rs
+++ b/src/property/colors.rs
@@ -1,17 +1,28 @@
 use bevy::prelude::Color;
 
-pub(super) fn parse_hex_color(hex: &str) -> Option<Color> {
-    if let Ok(cssparser::Color::RGBA(cssparser::RGBA {
+fn to_bevy_color(css_color: Option<cssparser::Color>) -> Option<Color> {
+    // TODO: Implement other colors type
+    if let Some(cssparser::Color::Rgba(cssparser::RGBA {
         red,
         green,
         blue,
         alpha,
-    })) = cssparser::Color::parse_hash(hex.as_bytes())
+    })) = css_color
     {
-        Some(Color::rgba_u8(red, green, blue, alpha))
+        let alpha = (alpha.unwrap_or_default() * 255.0) as u8;
+        Some(Color::rgba_u8(
+            red.unwrap_or_default(),
+            green.unwrap_or_default(),
+            blue.unwrap_or_default(),
+            alpha,
+        ))
     } else {
         None
     }
+}
+
+pub(super) fn parse_hex_color(hex: &str) -> Option<Color> {
+    to_bevy_color(cssparser::parse_hash_color(hex.as_bytes()).ok())
 }
 
 // Source: https://developer.mozilla.org/en-US/docs/Web/CSS/named-color
@@ -20,15 +31,5 @@ pub(super) fn parse_hex_color(hex: &str) -> Option<Color> {
 ///
 /// Accepts any [valid CSS named-colors](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color).
 pub(super) fn parse_named_color(name: &str) -> Option<Color> {
-    if let Ok(cssparser::Color::RGBA(cssparser::RGBA {
-        red,
-        green,
-        blue,
-        alpha,
-    })) = cssparser::parse_color_keyword(name)
-    {
-        Some(Color::rgba_u8(red, green, blue, alpha))
-    } else {
-        None
-    }
+    to_bevy_color(cssparser::parse_color_keyword(name).ok())
 }

--- a/src/property/colors.rs
+++ b/src/property/colors.rs
@@ -2,20 +2,14 @@ use bevy::prelude::Color;
 
 fn to_bevy_color(css_color: Option<cssparser::Color>) -> Option<Color> {
     // TODO: Implement other colors type
-    if let Some(cssparser::Color::Rgba(cssparser::RGBA {
+    if let Some(cssparser::Color::Rgba(cssparser::RgbaLegacy {
         red,
         green,
         blue,
         alpha,
     })) = css_color
     {
-        let alpha = (alpha.unwrap_or_default() * 255.0) as u8;
-        Some(Color::rgba_u8(
-            red.unwrap_or_default(),
-            green.unwrap_or_default(),
-            blue.unwrap_or_default(),
-            alpha,
-        ))
+        Some(Color::rgba_u8(red, green, blue, (alpha * 255.0) as u8))
     } else {
         None
     }

--- a/src/property/colors.rs
+++ b/src/property/colors.rs
@@ -1,22 +1,11 @@
 use bevy::prelude::Color;
 
-fn to_bevy_color(css_color: Option<cssparser::Color>) -> Option<Color> {
-    // TODO: Implement other colors type
-    if let Some(cssparser::Color::Rgba(cssparser::RgbaLegacy {
-        red,
-        green,
-        blue,
-        alpha,
-    })) = css_color
-    {
-        Some(Color::rgba_u8(red, green, blue, (alpha * 255.0) as u8))
+pub(super) fn parse_hex_color(hex: &str) -> Option<Color> {
+    if let Ok((r, g, b, a)) = cssparser::color::parse_hash_color(hex.as_bytes()) {
+        Some(Color::rgba_u8(r, g, b, (a * 255.0) as u8))
     } else {
         None
     }
-}
-
-pub(super) fn parse_hex_color(hex: &str) -> Option<Color> {
-    to_bevy_color(cssparser::parse_hash_color(hex.as_bytes()).ok())
 }
 
 // Source: https://developer.mozilla.org/en-US/docs/Web/CSS/named-color
@@ -25,5 +14,15 @@ pub(super) fn parse_hex_color(hex: &str) -> Option<Color> {
 ///
 /// Accepts any [valid CSS named-colors](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color).
 pub(super) fn parse_named_color(name: &str) -> Option<Color> {
-    to_bevy_color(cssparser::parse_color_keyword(name).ok())
+    if let Ok(cssparser_color::Color::Rgba(cssparser_color::RgbaLegacy {
+        red,
+        green,
+        blue,
+        alpha,
+    })) = cssparser_color::parse_color_keyword(name)
+    {
+        Some(Color::rgba_u8(red, green, blue, (alpha * 255.0) as u8))
+    } else {
+        None
+    }
 }


### PR DESCRIPTION
Fixes #31 

Most of the changes was related to `cssparser::Color` which has it's own crate after `0.33`. 

Another change is the required implementation of the new `RuleBodyItemParser` on `PropertyParser` to also implement `QualifiedRuleParser`.

In general, it's very painful to upgrade `cssparser` due to its lack of migration guide or even a decent changelog between versions. We should consider switching to https://github.com/parcel-bundler/lightningcss which not only uses `cssparser` but also `selector` (we implement our own selector logic, which isn't optimal).