### PR TITLE
Implement pseudo class selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for `:hover` pseudo-class.
 - Added support for [Pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes).
+
+## [0.5.0]
+
+### Added
+
 - New selectors for setting up BorderColor and Image texture.
 - New documentation available on: [link](https://afonsolage.github.io/bevy_ecss/).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for `:hover` pseudo-class.
+- Added support for [Pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes).
 - New selectors for setting up BorderColor and Image texture.
 - New documentation available on: [link](https://afonsolage.github.io/bevy_ecss/).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `:hover` pseudo-class.
 - Added support for [Pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes).
 
-## [0.5.0]
+## [0.5.1]
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ecss"
-version = "0.5.1"
+version = "0.6.0-dev"
 edition = "2021"
 categories = ["game-development", "gui", "web-programming"]
 description = "Allows using a subset of CSS to interact with Bevy ECS"

--- a/assets/sheets/dark_theme.css
+++ b/assets/sheets/dark_theme.css
@@ -66,10 +66,9 @@ button text {
     left: 10px;
     font-size: 20;
     color: azure;
-    text-content: "Lightness!";
+    text-content: "Darkness!";
 }
 
-:hover {
-    color: red;
-    text-content: "Switch to Darkness?";
+button:hover text {
+    text-content: "Switch to Lightness?";
 }

--- a/assets/sheets/dark_theme.css
+++ b/assets/sheets/dark_theme.css
@@ -68,3 +68,8 @@ button text {
     color: azure;
     text-content: "Lightness!";
 }
+
+:hover {
+    color: red;
+    text-content: "Switch to Darkness?";
+}

--- a/assets/sheets/light_theme.css
+++ b/assets/sheets/light_theme.css
@@ -66,5 +66,9 @@ button text {
     left: 10px;
     font-size: 20;
     color: #3b3f3f;
-    text-content: "Darkness!!!!";
+    text-content: "Lightness!!!!";
+}
+
+button:hover text {
+    text-content: "Switch to Darkness?";
 }

--- a/book/src/guide_css_subset.md
+++ b/book/src/guide_css_subset.md
@@ -6,11 +6,12 @@ Here you can find a list of all currently supported selectors and properties:
 
 ### <ins>Selectors</ins>
 
-|    Type     | Details                                                                                                       | Example              |
-| :---------: | :------------------------------------------------------------------------------------------------------------ | :------------------- |
-|   _Name_    | Selects by using `bevy` built-int [`Name`](https://docs.rs/bevy/latest/bevy/core/struct.Name.html) component. | `#inventory { ... }` |
-|   _Class_   | Selects by using `Class` component, which is provided by Bevy ECSS.                                           | `.enabled { ... }`   |
-| _Component_ | Selects by using any component, but it has to be registered before usage. You can find more details bellow.   | `button { ... }`     |
+|    Type       | Details                                                                                                       | Example              |
+| :-----------: | :------------------------------------------------------------------------------------------------------------ | :------------------- |
+|   _Name_      | Selects by using `bevy` built-int [`Name`](https://docs.rs/bevy/latest/bevy/core/struct.Name.html) component. | `#inventory { ... }` |
+|   _Class_     | Selects by using `Class` component, which is provided by Bevy ECSS.                                           | `.enabled { ... }`   |
+| _Component_   | Selects by using any component, but it has to be registered before usage. You can find more details bellow.   | `button { ... }`     |
+| _PseudoClass_ | Selects by using pseudo-classes. A list of supported pseudo-classes are listed at the end of the page.        | `:hover { ... }`     |
 
 You may combine any of the above selector types to create a complex selector, if you like so. For instance, `window.enabled.pop-up` select all `window`s, which are `enabled` and are of `pop-up` type. The same rules of [`CSS Class selectors`](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors) applies here. 
 
@@ -35,3 +36,9 @@ So it's possible to combine complex composed selectors with descendant combinato
 ```
 
 This rule will match all components which has a `Class` with the value of `border` and are descendant of any entity which has a `button` component _and_ a `Class` component with the value of `enabled` and also are descendant of any entity which has a `Name` component with value `main-menu`.
+
+### Supported pseudo-classes
+
+|       Pseudo-Class    |                                   Description                                               |
+|:---------------------:|:------------------------------------------------------------------------------------------- |
+|       `:hover`        |  Matches any entity which has `Interaction` component with `Interaction::Hovered` variant.  |

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -8,20 +8,25 @@ use bevy_ecss::prelude::{
 struct Title;
 
 fn main() {
-    App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                fit_canvas_to_parent: true,
-                canvas: Some("#bevy".to_string()),
-                ..default()
-            }),
+    let mut app = App::new();
+
+    app.add_plugins(DefaultPlugins.set(WindowPlugin {
+        primary_window: Some(Window {
+            fit_canvas_to_parent: true,
+            canvas: Some("#bevy".to_string()),
             ..default()
-        }))
-        .add_plugins(EcssPlugin::with_hot_reload())
-        .add_systems(Startup, setup)
-        .add_systems(Update, change_theme)
-        .register_component_selector::<Title>("title")
-        .run();
+        }),
+        ..default()
+    }))
+    .add_plugins(EcssPlugin::with_hot_reload())
+    .add_systems(Startup, setup)
+    .add_systems(Update, change_theme)
+    .register_component_selector::<Title>("title");
+
+    #[cfg(not(target_arch = "wasm32"))]
+    app.add_plugins(bevy_editor_pls::prelude::EditorPlugin::default());
+
+    app.run();
 }
 
 #[derive(Resource)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -60,9 +60,12 @@ fn format_error(error: ParseError<EcssError>) -> String {
     )
 }
 
+/// Helper enum to indicate if the next element to be processed if an element with prefix.
 enum NextElementWithPrefix {
     None,
+    // Prefixed by a `.` delimiter
     Class,
+    // prefixed by a `:`
     PseudoClass,
 }
 
@@ -91,7 +94,7 @@ impl<'i> QualifiedRuleParser<'i> for StyleSheetParser {
                             elements.push(SelectorElement::Class(v.to_string()))
                         }
                         NextElementWithPrefix::PseudoClass => {
-                            elements.push(SelectorElement::PseudoClass(v.to_string()))
+                            elements.push(SelectorElement::PseudoClass(v.into()))
                         }
                     }
                     next_element_with_prefix = NextElementWithPrefix::None;
@@ -215,7 +218,7 @@ fn parse_values<'i>(
 
 #[cfg(test)]
 mod tests {
-    use crate::property::PropertyToken;
+    use crate::{property::PropertyToken, selector::PseudoClassElement};
 
     use super::*;
 
@@ -363,7 +366,7 @@ mod tests {
             Class("b".to_string()),
             Name("c".to_string()),
             Class("d".to_string()),
-            PseudoClass("hover".to_string()),
+            PseudoClass(PseudoClassElement::Hover),
         ];
 
         expected
@@ -378,7 +381,7 @@ mod tests {
 
     #[test]
     fn parse_multiple_composed_selector_no_property() {
-        let rules = StyleSheetParser::parse("a.b #c .d e#f .g.h i j.k#l :m {}");
+        let rules = StyleSheetParser::parse("a.b #c .d e#f .g.h i j.k#l :hover {}");
         assert_eq!(rules.len(), 1, "Should have a single rule");
 
         let rule = &rules[0];
@@ -398,7 +401,7 @@ mod tests {
                 Class("k".to_string()),
                 Name("l".to_string())
             ],
-            smallvec![PseudoClass("m".to_string())],
+            smallvec![PseudoClass(PseudoClassElement::Hover)],
         ];
 
         expected
@@ -428,7 +431,7 @@ mod tests {
         use SelectorElement::*;
         let expected: SmallVec<[SmallVec<[SelectorElement; 8]>; 8]> = smallvec![smallvec![
             Component("a".to_string()),
-            PseudoClass("pseudo".to_string())
+            PseudoClass(PseudoClassElement::Unsupported)
         ],];
 
         expected

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -21,7 +21,9 @@ pub enum SelectorElement {
     PseudoClass(PseudoClassElement),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
+/// Represents a pseudo-class as per (mdn docs)[https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes]
+/// Not all pseudo-classes are supported, in which case, an `Unsupported` variant will be used.
+#[derive(Debug, Clone, Copy, PartialEq, cssparsertialOrd, Eq, Ord, Hash)]
 pub enum PseudoClassElement {
     Hover,
     Unsupported,

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -23,7 +23,7 @@ pub enum SelectorElement {
 
 /// Represents a pseudo-class as per (mdn docs)[https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes]
 /// Not all pseudo-classes are supported, in which case, an `Unsupported` variant will be used.
-#[derive(Debug, Clone, Copy, PartialEq, cssparsertialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum PseudoClassElement {
     Hover,
     Unsupported,

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -18,7 +18,31 @@ pub enum SelectorElement {
     /// Indicates a parent-child relation between previous elements and next elements, like `window .border`
     Child,
     /// A keyword added to a selector that specifies a special state of the selected element(s), like `button:hover`
-    PseudoClass(String),
+    PseudoClass(PseudoClassElement),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub enum PseudoClassElement {
+    Hover,
+    Unsupported,
+}
+
+impl std::fmt::Display for PseudoClassElement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PseudoClassElement::Hover => write!(f, "hover"),
+            PseudoClassElement::Unsupported => write!(f, "unsupported"),
+        }
+    }
+}
+
+impl<'a> From<&'a CowRcStr<'a>> for PseudoClassElement {
+    fn from(value: &'a CowRcStr<'a>) -> Self {
+        match value.as_ref() {
+            "hover" => PseudoClassElement::Hover,
+            _ => PseudoClassElement::Unsupported,
+        }
+    }
 }
 
 /// A selector parsed from a `css` rule. Each selector has a internal hash used to differentiate between many rules in the same sheet.
@@ -81,7 +105,7 @@ impl std::fmt::Display for Selector {
                 SelectorElement::Child => result.push(' '),
                 SelectorElement::PseudoClass(c) => {
                     result.push(':');
-                    result.push_str(c);
+                    result.push_str(&c.to_string());
                 }
             }
         }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -17,6 +17,8 @@ pub enum SelectorElement {
     Class(String),
     /// Indicates a parent-child relation between previous elements and next elements, like `window .border`
     Child,
+    /// A keyword added to a selector that specifies a special state of the selected element(s), like `button:hover`
+    PseudoClass(String),
 }
 
 /// A selector parsed from a `css` rule. Each selector has a internal hash used to differentiate between many rules in the same sheet.
@@ -77,6 +79,10 @@ impl std::fmt::Display for Selector {
                     result.push_str(c);
                 }
                 SelectorElement::Child => result.push(' '),
+                SelectorElement::PseudoClass(c) => {
+                    result.push(':');
+                    result.push_str(c);
+                }
             }
         }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -209,9 +209,27 @@ fn get_entities_with_pseudo_class(
     entities: SmallVec<[Entity; 8]>,
 ) -> SmallVec<[Entity; 8]> {
     match pseudo_class {
-        PseudoClassElement::Hover => todo!(),
+        PseudoClassElement::Hover => get_entities_with_pseudo_class_hover(world, entities),
         PseudoClassElement::Unsupported => entities,
     }
+}
+
+fn get_entities_with_pseudo_class_hover(
+    world: &World,
+    entities: SmallVec<[Entity; 8]>,
+) -> SmallVec<[Entity; 8]> {
+    entities
+        .into_iter()
+        .filter(|e| {
+            world
+                .entity(*e)
+                .get::<Interaction>()
+                .is_some_and(|interaction| {
+                    println!("Found: {:?}", interaction);
+                    matches!(interaction, Interaction::Hovered)
+                })
+        })
+        .collect()
 }
 
 /// Filters entities which have the components specified on selector, like "a" or "button".

--- a/src/system.rs
+++ b/src/system.rs
@@ -171,6 +171,9 @@ fn select_entities_node(
                 SelectorElement::Component(component) => {
                     get_entities_with_component(component.as_str(), world, registry, filter)
                 }
+                SelectorElement::PseudoClass(_pseudo_class) => {
+                    todo!()
+                }
                 // All child elements are filtered by [`get_parent_tree`](Selector::get_parent_tree)
                 SelectorElement::Child => unreachable!(),
             })

--- a/src/system.rs
+++ b/src/system.rs
@@ -5,7 +5,7 @@ use bevy::{
         AssetEvent, Assets, Changed, Children, Component, Deref, DerefMut, Entity, EventReader,
         Mut, Name, Query, Res, ResMut, Resource, With, World,
     },
-    ui::Node,
+    ui::{Interaction, Node},
     utils::HashMap,
 };
 use smallvec::SmallVec;
@@ -13,7 +13,7 @@ use smallvec::SmallVec;
 use crate::{
     component::{Class, MatchSelectorElement, StyleSheet},
     property::StyleSheetState,
-    selector::{Selector, SelectorElement},
+    selector::{PseudoClassElement, Selector, SelectorElement},
     StyleSheetAsset,
 };
 
@@ -171,8 +171,8 @@ fn select_entities_node(
                 SelectorElement::Component(component) => {
                     get_entities_with_component(component.as_str(), world, registry, filter)
                 }
-                SelectorElement::PseudoClass(_pseudo_class) => {
-                    todo!()
+                SelectorElement::PseudoClass(pseudo_class) => {
+                    get_entities_with_pseudo_class(world, *pseudo_class, filter)
                 }
                 // All child elements are filtered by [`get_parent_tree`](Selector::get_parent_tree)
                 SelectorElement::Child => unreachable!(),
@@ -201,6 +201,18 @@ where
             }
         })
         .collect()
+}
+
+/// Utility function to filter any entities by using a component with implements [`MatchSelectorElement`]
+fn get_entities_with_pseudo_class(
+    world: &World,
+    pseudo_class: PseudoClassElement,
+    filter: Option<SmallVec<[Entity; 8]>>,
+) -> SmallVec<[Entity; 8]> {
+    match pseudo_class {
+        PseudoClassElement::Hover => todo!(),
+        PseudoClassElement::Unsupported => filter.unwrap_or_default(),
+    }
 }
 
 /// Filters entities which have the components specified on selector, like "a" or "button".

--- a/src/system.rs
+++ b/src/system.rs
@@ -111,7 +111,7 @@ pub(crate) fn prepare_state(
 /// If no [`Children`] is supplied, then the selector is applied only on root entity.
 fn select_entities(
     root: Entity,
-    children: Option<&Children>,
+    maybe_children: Option<&Children>,
     selector: &Selector,
     world: &World,
     css_query: &CssQueryParam,
@@ -123,29 +123,31 @@ fn select_entities(
         return SmallVec::new();
     }
 
-    let mut filter = children.map(|children| {
-        // Include root, since style sheet may be applied on root too.
-        std::iter::once(root)
-            .chain(get_children_recursively(children, &css_query.children))
-            .collect()
-    });
+    // Build an entity tree with all entities that may be selected.
+    // This tree is composed of the entity root and all descendants entities.
+    let mut entity_tree = std::iter::once(root)
+        .chain(
+            maybe_children
+                .map(|children| get_children_recursively(children, &css_query.children))
+                .unwrap_or_default(),
+        )
+        .collect::<SmallVec<_>>();
 
     loop {
         // TODO: Rework this to use a index to avoid recreating parent_tree every time the systems runs.
         // This is has little to no impact on performance, since this system doesn't runs often.
         let node = parent_tree.remove(0);
 
-        let entities = select_entities_node(node, world, css_query, registry, filter.clone());
+        let entities = select_entities_node(node, world, css_query, registry, entity_tree.clone());
 
         if parent_tree.is_empty() {
             break entities;
         } else {
-            let children = entities
+            entity_tree = entities
                 .into_iter()
                 .filter_map(|e| css_query.children.get(e).ok())
                 .flat_map(|children| get_children_recursively(children, &css_query.children))
                 .collect();
-            filter = Some(children);
         }
     }
 }
@@ -157,47 +159,44 @@ fn select_entities_node(
     world: &World,
     css_query: &CssQueryParam,
     registry: &mut ComponentFilterRegistry,
-    filter: Option<SmallVec<[Entity; 8]>>,
+    entities: SmallVec<[Entity; 8]>,
 ) -> SmallVec<[Entity; 8]> {
-    node.into_iter()
-        .fold(filter, |filter, element| {
-            Some(match element {
-                SelectorElement::Name(name) => {
-                    get_entities_with(name.as_str(), &css_query.names, filter)
-                }
-                SelectorElement::Class(class) => {
-                    get_entities_with(class.as_str(), &css_query.classes, filter)
-                }
-                SelectorElement::Component(component) => {
-                    get_entities_with_component(component.as_str(), world, registry, filter)
-                }
-                SelectorElement::PseudoClass(pseudo_class) => {
-                    get_entities_with_pseudo_class(world, *pseudo_class, filter)
-                }
-                // All child elements are filtered by [`get_parent_tree`](Selector::get_parent_tree)
-                SelectorElement::Child => unreachable!(),
-            })
-        })
-        .unwrap_or_default()
+    node.into_iter().fold(entities, |entities, element| {
+        match element {
+            SelectorElement::Name(name) => {
+                get_entities_with(name.as_str(), &css_query.names, entities)
+            }
+            SelectorElement::Class(class) => {
+                get_entities_with(class.as_str(), &css_query.classes, entities)
+            }
+            SelectorElement::Component(component) => {
+                get_entities_with_component(component.as_str(), world, registry, entities)
+            }
+            SelectorElement::PseudoClass(pseudo_class) => {
+                get_entities_with_pseudo_class(world, *pseudo_class, entities)
+            }
+            // All child elements are filtered by [`get_parent_tree`](Selector::get_parent_tree)
+            SelectorElement::Child => unreachable!(),
+        }
+    })
 }
 
 /// Utility function to filter any entities by using a component with implements [`MatchSelectorElement`]
 fn get_entities_with<T>(
     name: &str,
     query: &Query<(Entity, &'static T)>,
-    filter: Option<SmallVec<[Entity; 8]>>,
+    entities: SmallVec<[Entity; 8]>,
 ) -> SmallVec<[Entity; 8]>
 where
     T: Component + MatchSelectorElement,
 {
     query
         .iter()
-        .filter_map(|(e, rhs)| if rhs.matches(name) { Some(e) } else { None })
-        .filter(|e| {
-            if let Some(filter) = &filter {
-                filter.contains(e)
+        .filter_map(|(e, rhs)| {
+            if entities.contains(&e) && rhs.matches(name) {
+                Some(e)
             } else {
-                true
+                None
             }
         })
         .collect()
@@ -207,11 +206,11 @@ where
 fn get_entities_with_pseudo_class(
     world: &World,
     pseudo_class: PseudoClassElement,
-    filter: Option<SmallVec<[Entity; 8]>>,
+    entities: SmallVec<[Entity; 8]>,
 ) -> SmallVec<[Entity; 8]> {
     match pseudo_class {
         PseudoClassElement::Hover => todo!(),
-        PseudoClassElement::Unsupported => filter.unwrap_or_default(),
+        PseudoClassElement::Unsupported => entities,
     }
 }
 
@@ -222,18 +221,14 @@ fn get_entities_with_component(
     name: &str,
     world: &World,
     components: &mut ComponentFilterRegistry,
-    filter: Option<SmallVec<[Entity; 8]>>,
+    entities: SmallVec<[Entity; 8]>,
 ) -> SmallVec<[Entity; 8]> {
     if let Some(query) = components.0.get_mut(name) {
-        if let Some(filter) = filter {
-            query
-                .filter(world)
-                .into_iter()
-                .filter(|e| filter.contains(e))
-                .collect()
-        } else {
-            query.filter(world)
-        }
+        query
+            .filter(world)
+            .into_iter()
+            .filter(|e| entities.contains(e))
+            .collect()
     } else {
         error!("Unregistered component selector {}", name);
         SmallVec::new()

--- a/src/system.rs
+++ b/src/system.rs
@@ -202,7 +202,7 @@ where
         .collect()
 }
 
-/// Utility function to filter any entities by using a component with implements [`MatchSelectorElement`]
+/// Utility function to filter any entities matching a [`PseudoClassElement`]
 fn get_entities_with_pseudo_class(
     world: &World,
     pseudo_class: PseudoClassElement,
@@ -214,6 +214,9 @@ fn get_entities_with_pseudo_class(
     }
 }
 
+/// Utility function to filter any entities matching a [`PseudoClassElement::Hover`] variant
+///
+/// This function looks for [`Interaction`] component with [`Interaction::Hovered`] variant.
 fn get_entities_with_pseudo_class_hover(
     world: &World,
     entities: SmallVec<[Entity; 8]>,
@@ -224,10 +227,7 @@ fn get_entities_with_pseudo_class_hover(
             world
                 .entity(*e)
                 .get::<Interaction>()
-                .is_some_and(|interaction| {
-                    println!("Found: {:?}", interaction);
-                    matches!(interaction, Interaction::Hovered)
-                })
+                .is_some_and(|interaction| matches!(interaction, Interaction::Hovered))
         })
         .collect()
 }


### PR DESCRIPTION
### Draft

I'm reworking `system::prepare_state` to support pseudo classes selectors. The main problem is find a way to have freedom to query for any component state, without having to statically add all of'em as query on `CssQueryParam`.

---

Fixes #18

## Added 
- `:hover` pseudo class selector, which corresponds to `Interaction::Hovered`;