### PR TITLE
Fixed css precedence ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Fixed CSS precedence order, more broad rules are applied first.
+
+
 ## [0.5.1]
 
 ### Added

--- a/assets/sheets/hot_reload.css
+++ b/assets/sheets/hot_reload.css
@@ -17,15 +17,16 @@
     height: 50%;
 }
 
-.big-text {
+text.big-text {
     font-size: 15;
     width: 100%;
-    color: #923192
+    color: #623192
 }
 
-#right-list text {
-    font-size: 16;
+text {
+    font-size: 19;
     vertical-align: bottom;
+    color: red;
 }
 
 .container .blue-bg {

--- a/assets/sheets/hot_reload.css
+++ b/assets/sheets/hot_reload.css
@@ -17,13 +17,13 @@
     height: 50%;
 }
 
-text.big-text {
+.big-text {
     font-size: 15;
     width: 100%;
     color: #623192
 }
 
-text {
+#right-list text {
     font-size: 19;
     vertical-align: bottom;
     color: red;

--- a/src/property/mod.rs
+++ b/src/property/mod.rs
@@ -244,7 +244,7 @@ impl<T: Property> PropertyMeta<T> {
 
 /// Maps which entities was selected by a [`Selector`]
 #[derive(Debug, Clone, Default, Deref, DerefMut)]
-pub struct SelectedEntities(HashMap<Selector, SmallVec<[Entity; 8]>>);
+pub struct SelectedEntities(SmallVec<[(Selector, SmallVec<[Entity; 8]>); 8]>);
 
 /// Maps sheets for each [`StyleSheetAsset`].
 #[derive(Debug, Clone, Default, Deref, DerefMut, Resource)]

--- a/src/system.rs
+++ b/src/system.rs
@@ -83,6 +83,8 @@ pub(crate) fn prepare_state(
 
     for (entity, children, sheet_handle) in &params.nodes {
         if let Some(sheet) = params.assets.get(sheet_handle.handle().id()) {
+            let map = state.entry(sheet_handle.handle().clone()).or_default();
+
             debug!("Applying style {}", sheet.path());
 
             for rule in sheet.iter() {
@@ -95,11 +97,10 @@ pub(crate) fn prepare_state(
                     entities.len()
                 );
 
-                state
-                    .entry(sheet_handle.handle().clone())
-                    .or_default()
-                    .insert(rule.selector.clone(), entities);
+                map.push((rule.selector.clone(), entities));
             }
+
+            map.sort_by(|(a, _), (b, _)| a.weight.cmp(&b.weight));
         }
     }
 


### PR DESCRIPTION
Fixes #21

Added an weight on `Selector` which is based on [Specificity by Mozilla](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity).

In short terms, we compute a sum based weight for each element on rule, where:
- `Component` names, since they are more broad, just add `1`;
- `Class` names are a bit more specific, so add `10`;
- `Name`s are very specific, so add `100`;
- `PseudoClass` adds the same as `Class`, so 10;

In that way:
- `.ui-bg text` would have a total weight of 11;
- `.ui-bg text:hover` would have a total weight of 21;
- `#alert.ui-bg text:hover` would have a total weight of 121;

Low weight rules are applied first so they got overwritten by high weight rules.