### PR TITLE
Selector detection change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added watch for changes on entities with components affected by css.
+
 ### Changed
 
 - Fixed CSS precedence order, more broad rules are applied first.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,7 @@ path = "examples/theme.rs"
 [[example]]
 name = "alpha"
 path = "examples/alpha.rs"
+
+[[example]]
+name = "interactive"
+path = "examples/interactive.rs"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Just because Bevy ECS + CSS is a perfect fit!
 
 ### Docs site
 
-Reference guide and more available here:
+Reference guide, examples and more available here:
 [docs](https://afonsolage.github.io/bevy_ecss/)
 
 ## Usage
@@ -45,7 +45,7 @@ That's it, now your UI will indeed look _awesome_!
 |  0.10 |    0.3    |
 |  0.11 |    0.4    |
 |  0.12 |    0.5    |
-
+|  0.12 |    0.6    |
 
 ## Contributing
 

--- a/assets/sheets/dark_theme.css
+++ b/assets/sheets/dark_theme.css
@@ -39,6 +39,10 @@
     color: red;
 }
 
+text {
+    color: blue;
+}
+
 #mid-blue-border {
     background-color: #0a0a24;
 }

--- a/assets/sheets/dark_theme.css
+++ b/assets/sheets/dark_theme.css
@@ -33,6 +33,12 @@
     color: #7c7c7c
 }
 
+.big-text-red {
+    font-size: 15;
+    width: 100%;
+    color: red;
+}
+
 #mid-blue-border {
     background-color: #0a0a24;
 }

--- a/assets/sheets/hot_reload.css
+++ b/assets/sheets/hot_reload.css
@@ -23,12 +23,17 @@
     color: #623192
 }
 
-#right-list text {
-    font-size: 19;
-    vertical-align: bottom;
+.big-text-red {
+    font-size: 15;
+    width: 100%;
     color: red;
 }
 
+#right-list text {
+    font-size: 19;
+    vertical-align: bottom;
+}
+
 .container .blue-bg {
-    background-color: #ff00FF10;
+    background-color: #0f00FF10;
 } 

--- a/assets/sheets/interactive.css
+++ b/assets/sheets/interactive.css
@@ -1,0 +1,33 @@
+#ui-root {
+	width: 30%;
+	height: 100%;
+	justfy-content: space-between;
+}
+
+#list {
+	background-color: #050505;
+	width: 100%;
+	height: 100%;
+	flex-direction: column-reverse;
+	align-self: center;
+	overflow: clip;
+}
+
+#panel {
+	flex-direction: column-reverse;
+	flex-grow: 1.0;
+}
+
+text {
+	font: "fonts/FiraSans-Bold.ttf";
+	font-size: 20;
+	color: white;
+	flex-shrink: 0;
+	height: 20px;
+	margin: auto;	
+}
+
+text:hover {
+	color: red;
+	font-size: 25;
+}

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -13,6 +13,8 @@
 - [Custom Property](./custom_property.md)
 
 # Examples
+
 - [Simple](./example_simple.md)
 - [Custom property](./example_alpha.md)
 - [Theme](./example_theme.md)
+- [Interactive](./example_interactive.md)

--- a/book/src/example_interactive.md
+++ b/book/src/example_interactive.md
@@ -1,0 +1,20 @@
+# Interactive example
+
+<canvas id="bevy"></canvas>
+<script type="module">
+    // Import and run your bevy wasm code
+    import init from './theme.js'
+    init();
+</script>
+
+## CSS
+
+```css
+{{#include ../../assets/sheets/interactive.css}}
+```
+
+## Code
+
+```rust
+{{#include ../../examples/interactive.rs}}
+```

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -1,0 +1,64 @@
+use bevy::{prelude::*, ui::FocusPolicy};
+use bevy_ecss::prelude::{EcssPlugin, StyleSheet};
+
+fn main() {
+    let mut app = App::new();
+
+    app.add_plugins(DefaultPlugins.set(WindowPlugin {
+        primary_window: Some(Window {
+            fit_canvas_to_parent: true,
+            canvas: Some("#bevy".to_string()),
+            ..default()
+        }),
+        ..default()
+    }))
+    .add_plugins(EcssPlugin::with_hot_reload())
+    .add_systems(Startup, setup);
+
+    #[cfg(not(target_arch = "wasm32"))]
+    app.add_plugins(bevy_editor_pls::prelude::EditorPlugin::default());
+
+    app.run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // Camera
+    commands.spawn(Camera2dBundle::default());
+
+    // root node
+    commands
+        .spawn(NodeBundle {
+            focus_policy: FocusPolicy::Pass,
+            ..default()
+        })
+        .insert(Name::new("ui-root"))
+        .insert(StyleSheet::new(asset_server.load("sheets/interactive.css")))
+        .with_children(|parent| {
+            parent
+                .spawn(NodeBundle {
+                    focus_policy: FocusPolicy::Pass,
+                    ..default()
+                })
+                .insert(Name::new("list"))
+                .with_children(|parent| {
+                    // Moving panel
+                    parent
+                        .spawn(NodeBundle {
+                            focus_policy: FocusPolicy::Pass,
+                            ..default()
+                        })
+                        .insert(Name::new("panel"))
+                        .with_children(|parent| {
+                            // List items
+                            for i in 0..30 {
+                                parent
+                                    .spawn(TextBundle::from_section(
+                                        format!("Item {i}"),
+                                        TextStyle::default(),
+                                    ))
+                                    .insert(Interaction::default());
+                            }
+                        });
+                });
+        });
+}

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -39,26 +39,15 @@ struct Themes {
 fn change_theme(
     themes: Res<Themes>,
     mut styles_query: Query<&mut StyleSheet>,
-    items_query: Query<(Entity, &Class), With<Node>>,
     interaction_query: Query<&Interaction, (Changed<Interaction>, With<Button>)>,
-    mut commands: Commands,
 ) {
     for interaction in &interaction_query {
         if let Interaction::Pressed = *interaction {
             if let Ok(mut sheet) = styles_query.get_mut(themes.root) {
                 if sheet.handle() == &themes.dark {
-                    // sheet.set(themes.light.clone());
-                    for (e, class) in items_query.iter() {
-                        if class.eq("big-text") {
-                            commands.entity(e).insert(Class::new("big-text-red"));
-                            println!("Updated to red!");
-                        } else if class.eq("big-text-red") {
-                            commands.entity(e).insert(Class::new("big-text"));
-                            println!("Updated to non-red!");
-                        }
-                    }
+                    sheet.set(themes.light.clone());
                 } else {
-                    // sheet.set(themes.dark.clone());
+                    sheet.set(themes.dark.clone());
                 }
             }
         }

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -410,12 +410,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.insert_resource(Themes { root, dark, light })
 }
 
-fn test_change_text(q_text: Query<(Entity, Option<&Name>), Changed<Text>>) {
-    for (e, maybe_name) in &q_text {
-        if let Some(name) = maybe_name {
-            println!("text changed: {:?} ({:?})", name, e);
-        } else {
-            println!("text changed: ({:?})", e);
+fn test_change_text(q_text: Query<(Entity, &Interaction, Option<&Name>), Changed<Interaction>>) {
+    for (e, interaction, maybe_name) in &q_text {
+        if interaction == &Interaction::Hovered {
+            println!(
+                "Hovering ({:?}){:?}",
+                e,
+                maybe_name.unwrap_or(&Name::new(""))
+            );
         }
     }
 }

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -20,7 +20,7 @@ fn main() {
     }))
     .add_plugins(EcssPlugin::with_hot_reload())
     .add_systems(Startup, setup)
-    .add_systems(Update, (change_theme, test_change_text))
+    .add_systems(Update, change_theme)
     .register_component_selector::<Title>("title");
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -397,16 +397,4 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .id();
 
     commands.insert_resource(Themes { root, dark, light })
-}
-
-fn test_change_text(q_text: Query<(Entity, &Interaction, Option<&Name>), Changed<Interaction>>) {
-    for (e, interaction, maybe_name) in &q_text {
-        if interaction == &Interaction::Hovered {
-            println!(
-                "Hovering ({:?}){:?}",
-                e,
-                maybe_name.unwrap_or(&Name::new(""))
-            );
-        }
-    }
 }

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -23,8 +23,8 @@ fn main() {
     .add_systems(Update, (change_theme, test_change_text))
     .register_component_selector::<Title>("title");
 
-    // #[cfg(not(target_arch = "wasm32"))]
-    // app.add_plugins(bevy_editor_pls::prelude::EditorPlugin::default());
+    #[cfg(not(target_arch = "wasm32"))]
+    app.add_plugins(bevy_editor_pls::prelude::EditorPlugin::default());
 
     app.run();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,10 +229,7 @@ impl RegisterComponentSelector for bevy::prelude::App {
         let boxed_state = Box::new(system_state);
 
         self.world
-            .get_resource_or_insert_with::<ComponentFilterRegistry>(|| {
-                ComponentFilterRegistry(Default::default())
-            })
-            .0
+            .get_resource_or_insert_with::<ComponentFilterRegistry>(bevy::utils::default)
             .insert(name, boxed_state);
 
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,10 @@ impl Plugin for EcssPlugin {
             .init_resource::<ComponentFilterRegistry>()
             .init_asset_loader::<StyleSheetLoader>()
             .add_systems(PreUpdate, system::prepare.in_set(EcssSet::Prepare))
-            .add_systems(PreUpdate, system::watch_tracked_entities)
+            .add_systems(
+                PreUpdate,
+                system::watch_tracked_entities.in_set(EcssSet::ChangeDetection),
+            )
             .add_systems(PostUpdate, system::clear_state.in_set(EcssSet::Cleanup));
 
         let prepared_state = PrepareParams::new(&mut app.world);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ struct EcssHotReload;
 /// System sets  used by `bevy_ecss` systems
 #[derive(SystemSet, Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum EcssSet {
+    /// Checks if any entity affected by some style sheet was changed.
+    /// Triggers [`StyleSheet::refresh`] if it does.
     ChangeDetection,
     /// Prepares internal state before running apply systems.
     /// This system runs on [`PreUpdate`] schedule.
@@ -108,7 +110,7 @@ impl Plugin for EcssPlugin {
             .init_asset::<StyleSheetAsset>()
             .configure_sets(
                 PreUpdate,
-                (EcssSet::ChangeDetection, EcssSet::Prepare, EcssSet::Apply).chain(),
+                (EcssSet::Prepare, EcssSet::ChangeDetection, EcssSet::Apply).chain(),
             )
             .configure_sets(PostUpdate, EcssSet::Cleanup)
             .init_resource::<StyleSheetState>()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -144,7 +144,9 @@ impl<'i> QualifiedRuleParser<'i> for StyleSheetParser {
                 Ok((name, property)) => {
                     rule.properties.insert(name, property);
                 }
-                Err((err, a)) => println!("Failed: {:?} ({})", err, a),
+                Err((err, a)) => {
+                    error!("Failed to parse property : {:?} ({})", err, a)
+                }
             }
         }
 

--- a/src/property/mod.rs
+++ b/src/property/mod.rs
@@ -254,7 +254,7 @@ pub struct SelectedEntities(SmallVec<[(Selector, SmallVec<[Entity; 8]>); 8]>);
 pub struct StyleSheetState(HashMap<AssetId<StyleSheetAsset>, (TrackedEntities, SelectedEntities)>);
 
 impl StyleSheetState {
-    pub(crate) fn has_selected_entities(&self) -> bool {
+    pub(crate) fn has_any_selected_entities(&self) -> bool {
         self.values().any(|(_, v)| !v.is_empty())
     }
 

--- a/src/property/mod.rs
+++ b/src/property/mod.rs
@@ -4,8 +4,8 @@ use bevy::{
     ecs::query::{QueryItem, ReadOnlyWorldQuery, WorldQuery},
     log::{error, trace},
     prelude::{
-        AssetId, AssetServer, Assets, Color, Commands, Deref, DerefMut, Entity, Handle, Local,
-        Query, Res, Resource,
+        AssetId, AssetServer, Assets, Color, Commands, Deref, DerefMut, Entity, Local, Query, Res,
+        Resource,
     },
     ui::{UiRect, Val},
     utils::HashMap,
@@ -14,7 +14,7 @@ use bevy::{
 use cssparser::Token;
 use smallvec::SmallVec;
 
-use crate::{selector::Selector, EcssError, StyleSheetAsset};
+use crate::{selector::Selector, EcssError, SelectorElement, StyleSheetAsset};
 
 mod colors;
 pub(crate) mod impls;
@@ -242,13 +242,26 @@ impl<T: Property> PropertyMeta<T> {
     }
 }
 
+#[derive(Debug, Clone, Default, Deref, DerefMut)]
+pub(crate) struct TrackedEntities(HashMap<SelectorElement, SmallVec<[Entity; 8]>>);
+
 /// Maps which entities was selected by a [`Selector`]
 #[derive(Debug, Clone, Default, Deref, DerefMut)]
 pub struct SelectedEntities(SmallVec<[(Selector, SmallVec<[Entity; 8]>); 8]>);
 
 /// Maps sheets for each [`StyleSheetAsset`].
-#[derive(Debug, Clone, Default, Deref, DerefMut, Resource)]
-pub struct StyleSheetState(HashMap<AssetId<StyleSheetAsset>, SelectedEntities>);
+#[derive(Debug, Clone, Default, Resource, Deref, DerefMut)]
+pub struct StyleSheetState(HashMap<AssetId<StyleSheetAsset>, (TrackedEntities, SelectedEntities)>);
+
+impl StyleSheetState {
+    pub(crate) fn has_selected_entities(&self) -> bool {
+        self.values().any(|(_, v)| !v.is_empty())
+    }
+
+    pub(crate) fn clear_selected_entities(&mut self) {
+        self.values_mut().for_each(|(_, v)| v.clear());
+    }
+}
 
 /// Determines how a property should interact and modify the [ecs world](`bevy::prelude::World`).
 ///
@@ -317,7 +330,8 @@ pub trait Property: Default + Sized + Send + Sync + 'static {
         asset_server: Res<AssetServer>,
         mut commands: Commands,
     ) {
-        for (asset_id, selected) in apply_sheets.iter() {
+        let stylesheet_map = &apply_sheets.stylesheet_map;
+        for (asset_id, selected) in stylesheet_map.iter() {
             if let Some(rules) = assets.get(*asset_id) {
                 for (selector, entities) in selected.iter() {
                     if let CacheState::Ok(cached) = local.get_or_parse(rules, selector) {

--- a/src/property/mod.rs
+++ b/src/property/mod.rs
@@ -243,7 +243,7 @@ impl<T: Property> PropertyMeta<T> {
 }
 
 #[derive(Debug, Clone, Default, Deref, DerefMut)]
-pub(crate) struct TrackedEntities(HashMap<SelectorElement, SmallVec<[Entity; 8]>>);
+pub struct TrackedEntities(HashMap<SelectorElement, SmallVec<[Entity; 8]>>);
 
 /// Maps which entities was selected by a [`Selector`]
 #[derive(Debug, Clone, Default, Deref, DerefMut)]
@@ -330,8 +330,7 @@ pub trait Property: Default + Sized + Send + Sync + 'static {
         asset_server: Res<AssetServer>,
         mut commands: Commands,
     ) {
-        let stylesheet_map = &apply_sheets.stylesheet_map;
-        for (asset_id, selected) in stylesheet_map.iter() {
+        for (asset_id, (_, selected)) in apply_sheets.iter() {
             if let Some(rules) = assets.get(*asset_id) {
                 for (selector, entities) in selected.iter() {
                     if let CacheState::Ok(cached) = local.get_or_parse(rules, selector) {

--- a/src/property/mod.rs
+++ b/src/property/mod.rs
@@ -4,8 +4,8 @@ use bevy::{
     ecs::query::{QueryItem, ReadOnlyWorldQuery, WorldQuery},
     log::{error, trace},
     prelude::{
-        AssetServer, Assets, Color, Commands, Deref, DerefMut, Entity, Handle, Local, Query, Res,
-        Resource,
+        AssetId, AssetServer, Assets, Color, Commands, Deref, DerefMut, Entity, Handle, Local,
+        Query, Res, Resource,
     },
     ui::{UiRect, Val},
     utils::HashMap,
@@ -248,7 +248,7 @@ pub struct SelectedEntities(SmallVec<[(Selector, SmallVec<[Entity; 8]>); 8]>);
 
 /// Maps sheets for each [`StyleSheetAsset`].
 #[derive(Debug, Clone, Default, Deref, DerefMut, Resource)]
-pub struct StyleSheetState(HashMap<Handle<StyleSheetAsset>, SelectedEntities>);
+pub struct StyleSheetState(HashMap<AssetId<StyleSheetAsset>, SelectedEntities>);
 
 /// Determines how a property should interact and modify the [ecs world](`bevy::prelude::World`).
 ///
@@ -317,8 +317,8 @@ pub trait Property: Default + Sized + Send + Sync + 'static {
         asset_server: Res<AssetServer>,
         mut commands: Commands,
     ) {
-        for (handle, selected) in apply_sheets.iter() {
-            if let Some(rules) = assets.get(handle) {
+        for (asset_id, selected) in apply_sheets.iter() {
+            if let Some(rules) = assets.get(*asset_id) {
                 for (selector, entities) in selected.iter() {
                     if let CacheState::Ok(cached) = local.get_or_parse(rules, selector) {
                         trace!(

--- a/src/system.rs
+++ b/src/system.rs
@@ -446,10 +446,7 @@ fn any_pseudo_class_changed(
     pseudo_class: PseudoClassElement,
 ) -> bool {
     match pseudo_class {
-        PseudoClassElement::Hover => {
-            trace!("Checking for changes on hovered: {:?}", entities.len());
-            any_changed::<Interaction>(world, entities)
-        }
+        PseudoClassElement::Hover => any_changed::<Interaction>(world, entities),
         PseudoClassElement::Unsupported => false,
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -82,8 +82,9 @@ pub(crate) fn prepare_state(
     let mut state = StyleSheetState::default();
 
     for (entity, children, sheet_handle) in &params.nodes {
-        if let Some(sheet) = params.assets.get(sheet_handle.handle().id()) {
-            let map = state.entry(sheet_handle.handle().clone()).or_default();
+        let id = sheet_handle.handle().id();
+        if let Some(sheet) = params.assets.get(id) {
+            let map = state.entry(id).or_default();
 
             debug!("Applying style {}", sheet.path());
 


### PR DESCRIPTION
Fixes #39 

### Changed
- `Selector`s will now detect changes on entities and apply the stylesheet;

---

Overall I have to track which `SelectorElement` matched which `Entity`, so we can convert the given `SelectorElement` into a `Query<T>` and use `bevy_ecs` to keep track of changes. When some `Entity` is changed, the whole `StyleSheet` will be applied, since fine grain control over will be very complex and I don't think it'll worth it at the end, since applying a `StyleSheet` is cheap (even tho there are plenty of optimization left to do).

`StyleSheetState` now has another member, for each `Asset<StyleSheetAsset>`. The new `TrackedEntities` member is populated when `system::select_entities` in ran, that way, we don't have to traverse the entity tree twice.

TODO:
- [x] Find a way to get a `Query<T>` from a `SelectorElement` inside the `watch_tracked_entities` system;
- [x] Write some examples;
- [x] Update docs and changelog;