### PR TITLE
Added Class Component Modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for applying multiple style sheets to an entity [#45](https://github.com/afonsolage/bevy_ecss/issues/45)
+- Added quality of life methods for modifying class lists on existing class components. [#48](https://github.com/afonsolage/bevy_ecss/pull/48)
 
 ### Changed
 
@@ -24,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed CSS precedence order, more broad rules are applied first.
-
 
 ## [0.5.1]
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -45,7 +45,7 @@ impl Class {
     ///
     /// This method returns `true` if the class was modified, `false` otherwise.
     /// You can use this to check if the style sheet needs to be refreshed.
-    pub fn add_class(&mut self, class: &str) -> bool {
+    pub fn add(&mut self, class: &str) -> bool {
         if self.matches(class) {
             return false;
         }
@@ -69,7 +69,7 @@ impl Class {
     ///
     /// This method returns `true` if the class was modified, `false` otherwise.
     /// You can use this to check if the style sheet needs to be refreshed.
-    pub fn remove_class(&mut self, class: &str) -> bool {
+    pub fn remove(&mut self, class: &str) -> bool {
         if !self.matches(class) {
             return false;
         }
@@ -94,7 +94,7 @@ impl Class {
     ///
     /// This method returns `true` if the class was modified, `false` otherwise.
     /// You can use this to check if the style sheet needs to be refreshed.
-    pub fn set_class(&mut self, class: impl Into<Cow<'static, str>>) -> bool {
+    pub fn set(&mut self, class: impl Into<Cow<'static, str>>) -> bool {
         let class = class.into();
 
         if self.0 == class {
@@ -212,22 +212,22 @@ mod tests {
     #[test]
     fn modify_class() {
         let mut class = Class::new("yellow-button");
-        assert!(class.add_class("enabled"));
+        assert!(class.add("enabled"));
         assert_eq!(class.0, "yellow-button enabled");
 
-        assert!(!class.add_class("enabled"));
+        assert!(!class.add("enabled"));
         assert_eq!(class.0, "yellow-button enabled");
 
-        assert!(!class.remove_class("disabled"));
+        assert!(!class.remove("disabled"));
         assert_eq!(class.0, "yellow-button enabled");
 
-        assert!(class.remove_class("enabled"));
+        assert!(class.remove("enabled"));
         assert_eq!(class.0, "yellow-button");
 
-        assert!(class.set_class("blue-button enabled"));
+        assert!(class.set("blue-button enabled"));
         assert_eq!(class.0, "blue-button enabled");
 
-        assert!(!class.set_class("blue-button enabled"));
+        assert!(!class.set("blue-button enabled"));
         assert_eq!(class.0, "blue-button enabled");
     }
 }

--- a/src/component.rs
+++ b/src/component.rs
@@ -35,6 +35,43 @@ impl Class {
     fn matches(&self, class: &str) -> bool {
         self.0.split_ascii_whitespace().any(|c| c == class)
     }
+
+    /// Appends a new class name to this component. If the class name is already
+    /// present, it will be ignored.
+    pub fn add_class(&mut self, class: &str) {
+        if self.matches(class) {
+            return;
+        }
+
+        if self.0.is_empty() {
+            self.0.to_mut().push_str(class);
+        } else {
+            self.0.to_mut().push(' ');
+            self.0.to_mut().push_str(class);
+        }
+    }
+
+    /// Removes a class name from this component. If the class name is not
+    /// present, it will be ignored.
+    pub fn remove_class(&mut self, class: &str) {
+        if !self.matches(class) {
+            return;
+        }
+
+        self.0 = self
+            .0
+            .split_ascii_whitespace()
+            .filter(move |c| c != &class)
+            .collect::<Vec<_>>()
+            .join(" ")
+            .into();
+    }
+
+    /// Replaces all class names with the given one as if a new Class component
+    /// was created.
+    pub fn set_class(&mut self, class: impl Into<Cow<'static, str>>) {
+        self.0 = class.into();
+    }
 }
 
 /// Applies a [`StyleSheetAsset`] on the entity which has this component.


### PR DESCRIPTION
I added the ability to add and remove individual class names to a `Class` component after creation. This should make it easier to add dynamic, code-reactive elements to a menu. (I.e, disabling one button if another checkbox is ticked.)