### PR TITLE
Upgrade to Bevy 0 13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ repository = "https://github.com/afonsolage/bevy_ecss"
 
 [dependencies]
 
-#bevy = { version = "0.12", default-features = false, features = [
-bevy = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
+bevy = { version = "0.13", default-features = false, features = [
     "bevy_ui",
     "bevy_asset",
     "bevy_text",
@@ -25,8 +24,7 @@ smallvec = { version = "1.11", features = ["serde", "union", "const_generics"] }
 thiserror = "1.0.50"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-#bevy = { version = "0.12", features = [
-bevy = { git = "https://github.com/bevyengine/bevy.git", features = [
+bevy = { version = "0.13", features = [
     "bevy_ui",
     "bevy_asset",
     "bevy_text",
@@ -35,8 +33,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", features = [
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-#bevy = "0.12"
-bevy = { git = "https://github.com/bevyengine/bevy.git"}
+bevy = "0.13"
 
 [[example]]
 name = "simple_ui"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ readme = "README.md"
 repository = "https://github.com/afonsolage/bevy_ecss"
 
 [dependencies]
-bevy = { version = "0.12", default-features = false, features = [
+
+#bevy = { version = "0.12", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
     "bevy_ui",
     "bevy_asset",
     "bevy_text",
@@ -23,7 +25,8 @@ smallvec = { version = "1.11", features = ["serde", "union", "const_generics"] }
 thiserror = "1.0.50"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { version = "0.12", features = [
+#bevy = { version = "0.12", features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", features = [
     "bevy_ui",
     "bevy_asset",
     "bevy_text",
@@ -33,7 +36,8 @@ bevy = { version = "0.12", features = [
 bevy_editor_pls = "0.6"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-bevy = "0.12"
+#bevy = "0.12"
+bevy = { git = "https://github.com/bevyengine/bevy.git"}
 
 [[example]]
 name = "simple_ui"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", features = [
     "bevy_render",
     "file_watcher",
 ] }
-bevy_editor_pls = "0.6"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 #bevy = "0.12"

--- a/examples/alpha.rs
+++ b/examples/alpha.rs
@@ -5,7 +5,6 @@ fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
-            fit_canvas_to_parent: true,
             canvas: Some("#bevy".to_string()),
             ..default()
         }),

--- a/examples/hot_reload.rs
+++ b/examples/hot_reload.rs
@@ -14,9 +14,6 @@ fn main() {
     .add_plugins(EcssPlugin::with_hot_reload())
     .add_systems(Startup, setup);
 
-    #[cfg(not(target_arch = "wasm32"))]
-    app.add_plugins(bevy_editor_pls::prelude::EditorPlugin::default());
-
     app.run();
 }
 

--- a/examples/hot_reload.rs
+++ b/examples/hot_reload.rs
@@ -6,7 +6,6 @@ fn main() {
     // Whenever an StyleSheet is loaded, it'll be applied automatically
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
-            fit_canvas_to_parent: true,
             canvas: Some("#bevy".to_string()),
             ..default()
         }),

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -14,9 +14,6 @@ fn main() {
     .add_plugins(EcssPlugin::with_hot_reload())
     .add_systems(Startup, setup);
 
-    #[cfg(not(target_arch = "wasm32"))]
-    app.add_plugins(bevy_editor_pls::prelude::EditorPlugin::default());
-
     app.run();
 }
 

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -6,7 +6,6 @@ fn main() {
 
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
-            fit_canvas_to_parent: true,
             canvas: Some("#bevy".to_string()),
             ..default()
         }),

--- a/examples/simple_ui.rs
+++ b/examples/simple_ui.rs
@@ -5,7 +5,6 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
-                fit_canvas_to_parent: true,
                 canvas: Some("#bevy".to_string()),
                 ..default()
             }),

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -5,7 +5,6 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
-                fit_canvas_to_parent: true,
                 canvas: Some("#bevy".to_string()),
                 ..default()
             }),

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -22,9 +22,6 @@ fn main() {
     .add_systems(Update, change_theme)
     .register_component_selector::<Title>("title");
 
-    #[cfg(not(target_arch = "wasm32"))]
-    app.add_plugins(bevy_editor_pls::prelude::EditorPlugin::default());
-
     app.run();
 }
 

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -12,7 +12,6 @@ fn main() {
 
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
-            fit_canvas_to_parent: true,
             canvas: Some("#bevy".to_string()),
             ..default()
         }),

--- a/src/property/impls.rs
+++ b/src/property/impls.rs
@@ -356,13 +356,13 @@ mod text {
         }
     }
 
-    /// Applies the `text-align` property on [`Text::horizontal`](`TextAlignment`) components.
+    /// Applies the `text-align` property on [`Text::horizontal`](`JustifyText`) components.
     #[derive(Default)]
     pub(crate) struct TextAlignProperty;
 
     impl Property for TextAlignProperty {
         // Using Option since Cache must impl Default, which  doesn't
-        type Cache = Option<TextAlignment>;
+        type Cache = Option<JustifyText>;
         type Components = &'static mut Text;
         type Filters = With<Node>;
 
@@ -373,9 +373,9 @@ mod text {
         fn parse<'a>(values: &PropertyValues) -> Result<Self::Cache, EcssError> {
             if let Some(ident) = values.identifier() {
                 match ident {
-                    "left" => return Ok(Some(TextAlignment::Left)),
-                    "center" => return Ok(Some(TextAlignment::Center)),
-                    "right" => return Ok(Some(TextAlignment::Right)),
+                    "left" => return Ok(Some(JustifyText::Left)),
+                    "center" => return Ok(Some(JustifyText::Center)),
+                    "right" => return Ok(Some(JustifyText::Right)),
                     _ => (),
                 }
             }
@@ -388,7 +388,7 @@ mod text {
             _asset_server: &AssetServer,
             _commands: &mut Commands,
         ) {
-            components.alignment = cache.expect("Should always have a inner value");
+            components.justify = cache.expect("Should always have a inner value");
         }
     }
 

--- a/src/property/mod.rs
+++ b/src/property/mod.rs
@@ -273,10 +273,10 @@ impl StyleSheetState {
 /// On the first time the `system` runs it'll call [`parse`](`Property::parse`) and cache the value.
 /// Subsequential runs will only fetch the cached value.
 /// - [`Components`](Property::Components) is which components will be send to [`apply`](`Property::apply`) function whenever a
-/// valid cache exists and a matching property was found on any sheet rule. Check [`WorldQuery`] for more.
+/// valid cache exists and a matching property was found on any sheet rule. Check [`QueryData`] for more.
 /// - [`Filters`](Property::Filters) is used to filter which entities will be applied the property modification.
 /// Entities are first filtered by [`selectors`](`Selector`), but it can be useful to also ensure some behavior for safety reasons,
-/// like only inserting [`TextAlignment`](bevy::prelude::TextAlignment) if the entity also has a [`Text`](bevy::prelude::Text) component.
+/// like only inserting [`JustifyText`](bevy::prelude::JustifyText) if the entity also has a [`Text`](bevy::prelude::Text) component.
 ///  Check [`WorldQuery`] for more.
 ///
 /// These are tree functions required to be implemented:
@@ -286,14 +286,14 @@ impl StyleSheetState {
 /// Additionally, an [`AssetServer`] and [`Commands`] parameters are provided for more complex use cases.
 ///
 /// Also, there one function which have default implementations:
-/// - [`apply_system`](Property::apply_system) is a [`system`](https://docs.rs/bevy_ecs/0.8.1/bevy_ecs/system/index.html) which interacts with
+/// - [`apply_system`](Property::apply_system) is a [`system`](https://docs.rs/bevy_ecs/latest/bevy_ecs/system/index.html) which interacts with
 /// [ecs world](`bevy::prelude::World`) and call the [`apply`](Property::apply) function on every matched entity.
 pub trait Property: Default + Sized + Send + Sync + 'static {
     /// The cached value type to be applied by property.
     type Cache: Default + Any + Send + Sync;
-    /// Which components should be queried when applying the modification. Check [`WorldQuery`] for more.
+    /// Which components should be queried when applying the modification. Check [`QueryData`] for more.
     type Components: QueryData;
-    /// Filters conditions to be applied when querying entities by this property. Check [`ReadOnlyWorldQuery`] for more.
+    /// Filters conditions to be applied when querying entities by this property. Check [`QueryFilter`] for more.
     type Filters: QueryFilter;
 
     /// Indicates which property name should matched for. Must match the same property name as on `css` file.
@@ -318,7 +318,7 @@ pub trait Property: Default + Sized + Send + Sync + 'static {
         commands: &mut Commands,
     );
 
-    /// The [`system`](https://docs.rs/bevy_ecs/0.8.1/bevy_ecs/system/index.html) which interacts with
+    /// The [`system`](https://docs.rs/bevy_ecs/latest/bevy_ecs/system/index.html) which interacts with
     /// [ecs world](`bevy::prelude::World`) and call [`apply`](Property::apply) function on every matched entity.
     ///
     /// The default implementation will cover most use cases, by just implementing [`apply`](Property::apply)

--- a/src/property/mod.rs
+++ b/src/property/mod.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 
 use bevy::{
-    ecs::query::{QueryItem, ReadOnlyWorldQuery, WorldQuery},
+    ecs::query::{QueryData, QueryFilter, QueryItem},
     log::{error, trace},
     prelude::{
         AssetId, AssetServer, Assets, Color, Commands, Deref, DerefMut, Entity, Local, Query, Res,
@@ -292,9 +292,9 @@ pub trait Property: Default + Sized + Send + Sync + 'static {
     /// The cached value type to be applied by property.
     type Cache: Default + Any + Send + Sync;
     /// Which components should be queried when applying the modification. Check [`WorldQuery`] for more.
-    type Components: WorldQuery;
+    type Components: QueryData;
     /// Filters conditions to be applied when querying entities by this property. Check [`ReadOnlyWorldQuery`] for more.
-    type Filters: ReadOnlyWorldQuery;
+    type Filters: QueryFilter;
 
     /// Indicates which property name should matched for. Must match the same property name as on `css` file.
     ///

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use bevy::{
     asset::{io::Reader, AssetLoader, AsyncReadExt},
     prelude::Asset,
-    reflect::{TypePath, TypeUuid},
+    reflect::TypePath,
     utils::{AHasher, HashMap},
 };
 use smallvec::SmallVec;
@@ -11,8 +11,7 @@ use thiserror::Error;
 
 use crate::{parser::StyleSheetParser, property::PropertyValues, selector::Selector};
 
-#[derive(Debug, TypeUuid, TypePath, Asset)]
-#[uuid = "14b98dd6-5425-4692-a561-5e6ae9180554"]
+#[derive(Debug, TypePath, Asset)]
 /// A cascading style sheet (`css`) asset file.
 ///
 /// _Note_: This asset only store intermediate data, like rules and properties.


### PR DESCRIPTION
The upgrade was very straightforward. The only note is that I removed `bevy_editor_pls` since it was used only on some test, most for debug purpose.

As soon Bevy 0.13 is published on crates.io, I'll merge this.